### PR TITLE
Makes module installable with Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "lilmuckers/magento-lilmuckers_queue",
+    "type": "magento-module",
+    "license":"MIT",
+    "description":"A generic multi-adapter queuing system for magento.",
+    "authors":[
+        {
+            "name":"Patrick McKinley",
+            "email":"contact@patrick-mckinley.com"
+        }
+    ],
+    "require": {
+        "magento-hackathon/magento-composer-installer": "*"
+    }
+}


### PR DESCRIPTION
Adds composer.json file that makes the extension installable with Composer (using Magento Composer Installer https://github.com/magento-hackathon/magento-composer-installer)
