### PR TITLE
Adds support to composer installed AWS SDK

### DIFF
--- a/app/code/community/Lilmuckers/Queue/Model/Adapter/Amazon.php
+++ b/app/code/community/Lilmuckers/Queue/Model/Adapter/Amazon.php
@@ -8,9 +8,11 @@
  * @license     http://choosealicense.com/licenses/mit/
  */
 
-//include the AWS auto-loader, because the weird namespacing doesn't play nice
-//with Magentos auto-loader.
-require 'AWSSDKforPHP/aws.phar';
+if (!class_exists('Aws\Sqs\SqsClient')) {
+    //include the AWS auto-loader, because the weird namespacing doesn't play nice
+    //with Magentos auto-loader.
+    require 'AWSSDKforPHP/aws.phar';
+}
 
 //use the namespaces we need
 use Aws\Sqs\Enum\QueueAttribute;


### PR DESCRIPTION
In our Magento projects we use firegento/psr0autoloader to support autoloading of packages installed by Composer. We would like to use newer versions of AWS SDK by installing it with Composer in our project. But, in such situation, the require of `AWSSDKforPHP/aws.phar` fails because that file only exists in the PEAR package. With this change, the require of `AWSSDKforPHP/aws.phar` is done only if the `Aws\Sqs\SqsClient` class is not already loaded.