### PR TITLE
Allow running queue.php from any working dir

### DIFF
--- a/shell/queue.php
+++ b/shell/queue.php
@@ -7,8 +7,14 @@
  * @copyright   Copyright (c) 2013 Patrick McKinley (http://www.patrick-mckinley.com)
  * @license     http://choosealicense.com/licenses/mit/
  */
- 
-require_once 'abstract.php';
+
+// This allows the script to run without shell/ being the current working dir.
+$relativePath = dirname($_SERVER['SCRIPT_FILENAME']);
+if ($relativePath && file_exists($relativePath . '/abstract.php')) {
+    require_once $relativePath . '/abstract.php';
+} else {
+    require_once 'abstract.php';
+}
 
 /**
  * Queue processor script


### PR DESCRIPTION
This prevents scripts executing the queue from having to cd into shell/ before executing the script.  Just a little peeve of mine, having to add `cd &&` everywhere.

Note that cli populates `SCRIPT_FILENAME` with `argv[0]`.  This works fine on Windows, Mac, and Linux.  It specifically supports a symlinked setup where shell/queue.php is a symlink, but works also when copied.

If for some reason someone does e.g. `cd shell/ && php ../.modman/magento-lilmuckers_queue/shell/queue.php`, it will fall back to the existing behavior and use `abstract.php` in the current working dir.