### PR TITLE
Fixes a PHP 7 notice

### DIFF
--- a/app/code/community/Lilmuckers/Queue/Model/Adapter/Amazon.php
+++ b/app/code/community/Lilmuckers/Queue/Model/Adapter/Amazon.php
@@ -293,7 +293,8 @@ class Lilmuckers_Queue_Model_Adapter_Amazon extends Lilmuckers_Queue_Model_Adapt
         }
         
         //pull off the only thing we're interested in - the first message
-        $_job = array_shift(array_values($job->get('Messages')));
+        $_messages = array_values($job->get('Messages'));    //PHP 7 fix
+        $_job = array_shift($_messages);
         
         //set the queue
         $_job['Queue'] = $queue;


### PR DESCRIPTION
PHP 7 complains that "Only variables should be passed by reference" to array_shift(). This should fix this notice.